### PR TITLE
Properly reply when given an exception

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/reply "0.6.3"
+(defproject clanhr/reply "0.6.4"
   :description "FIXME: write description"
   :url "http://github.com/clanhr/reply"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/reply/core.clj
+++ b/src/clanhr/reply/core.clj
@@ -76,4 +76,5 @@
   (cond
     (:success result) (ok result)
     (:unauthorised result) (unauthorized result)
+    (:exception result) (exception (:exception result))
     :else (bad-request result)))


### PR DESCRIPTION
As it was, the customer could get the full stack. And the exception
object may not be serializable to JSON and that would throw an error.
Now we just return the exception message.
