### PR TITLE
Don't auto dump json

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject clanhr/reply "0.11.0"
+(defproject clanhr/reply "1.0.0"
   :description "FIXME: write description"
   :url "http://github.com/clanhr/reply"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cheshire "5.5.0"]
-                 [manifold "0.1.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [cheshire "5.6.1"]
+                 [manifold "0.1.4"]
                  [mvxcvi/puget "1.0.0"]
                  [org.clojure/core.async "0.2.374"]
                  [clj-time "0.11.0"]])

--- a/src/clanhr/reply/core.clj
+++ b/src/clanhr/reply/core.clj
@@ -25,7 +25,7 @@
   ([status info content-type]
    {:status status
     :headers {"Content-Type" content-type}
-    :body (json/dump info)}))
+    :body info}))
 
 (defn file
   "Builds a response for a given file path"

--- a/test/clanhr/reply/core_test.clj
+++ b/test/clanhr/reply/core_test.clj
@@ -94,7 +94,7 @@
 (deftest async-reply-test
   (let [response @(reply/async-reply (reply/ok 1))]
     (is (= 200 (:status response)))
-    (is (= "1" (:body response)))))
+    (is (= 1 (:body response)))))
 
 (deftest async-result-test
   (testing "ok"


### PR DESCRIPTION
Motivation:

On adding swagger, the schema validation runs on what reply returns. If
reply returns the body as a string, the schema validation will fail.

Modifications:

Don't auto dump json.

Result:

This actually doesn't have an impact on the services, because there was
something on the pipeline that already converted to json.
